### PR TITLE
Binary klv input file

### DIFF
--- a/open_telemetry_kit/klvparser.py
+++ b/open_telemetry_kit/klvparser.py
@@ -39,11 +39,15 @@ class KLVParser(Parser):
 
   def read(self):
     metadata = read_video_metadata(self.source)
-    klv = read_klv(self.source, metadata)
+    if metadata:
+      klv = read_klv(self.source, metadata)
+    else:
+      with open(self.source, "rb") as b:
+        klv = b.read()
     self.klv_stream = BytesIO(klv)
 
     return self._parse()
-    
+
   def _parse(self):
     stream_end = self.klv_stream.seek(0, os.SEEK_END)
     self.klv_stream.seek(0, os.SEEK_SET)
@@ -97,7 +101,7 @@ class KLVParser(Parser):
           packet[self.element_dict[tag].misb_name] = self.element_dict[tag].fromMISB(value)
         else:
           packet[self.element_dict[tag].name] = self.element_dict[tag].fromMISB(value)
-      else: 
+      else:
         self.logger.warn("Parsed an unrecognized tag. Creating an UnknownElement")
         packet["Tag " + str(tag)] = UnknownElement(value)
 
@@ -129,4 +133,3 @@ class KLVParser(Parser):
 
     tag = (tag << 7) + (tag_byte)
     return tag
-    


### PR DESCRIPTION
This pull request adds the feature to allow binary files as input to `KLV_Parser`. For example, using ffmpeg to output a KLV Data stream as a binary file with the extension `.klv`, this file can be used as input to `detector.create_telemetry_parser(source)` in quickstart.py to successfully load, read, and write the binary data to json.

    python quickstart.py binary_klv_stream_1.klv output/path/

Specifically, `if metadata` was added to the `KLVParser.read()` method. The ffmpeg cmd used by `read_video_metadata()` will return `None` if provided a binary file. If `metadata` is `None` after executing `metadata = read_video_metadata(self.source)` then the source file is read in byte mode and stored as the `klv` variable. 

The initial reason for this is because I often have multiple KLV streams within a single TS file. As it stands, this package will only handle the first KLV stream found within a TS file. With this change, I can now use ffmpeg to dump each KLV stream into a binary file and then run each file through quickstart.py. The other option I considered would probably require alot more code changes to open-telemetry-kit so that it automatically handles multiple KLV streams. I went the route of least refactor and change.